### PR TITLE
Fix CRoom (kind of) and CLayer structs

### DIFF
--- a/RNSReloaded.Interfaces/Structs.cs
+++ b/RNSReloaded.Interfaces/Structs.cs
@@ -262,10 +262,13 @@ public unsafe struct CLayerElementBase {
     public LayerElementType Type;
     public int ID;
     public byte RuntimeDataInitialized;
+    public byte Unknown; // Unsure what this is but it's set to 1 so probably a byte
     public char* Name;
     public CLayer* Layer;
+    public fixed long Padding[2]; // Both seem null
     public CLayerElementBase* Next;
     public CLayerElementBase* Previous;
+    // Random 3 bytes of data, then 5 of pack, then another pointer. Who knows what that is though.
 }
 
 [StructLayout(LayoutKind.Sequential, Pack = 8)]

--- a/RNSReloaded.ReColor/ModConfig.json
+++ b/RNSReloaded.ReColor/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "RNSReloaded.ReColor",
   "ModName": "ReColor",
   "ModAuthor": "fuzzything44",
-  "ModVersion": "1.0.1",
+  "ModVersion": "1.0.2",
   "ModDescription": "Allows recoloring of color match rings. Maybe other attacks in the future.",
   "ModDll": "RNSReloaded.ReColor.dll",
   "ModIcon": "",

--- a/RNSReloaded/ModConfig.json
+++ b/RNSReloaded/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "RNSReloaded",
   "ModName": "RNSReloaded",
   "ModAuthor": "NotNite",
-  "ModVersion": "1.1.16",
+  "ModVersion": "1.1.17",
   "ModDescription": "Helper library for Rabbit and Steel. Can be adapted to general GameMaker.",
   "ModDll": "RNSReloaded.dll",
   "ModIcon": "",

--- a/RnsReloaded.FuzzyMechanicPack/ModConfig.json
+++ b/RnsReloaded.FuzzyMechanicPack/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "RNSReloaded.FuzzyMechanicPack",
   "ModName": "Fuzzy's Mechanic Pack",
   "ModAuthor": "fuzzything44",
-  "ModVersion": "0.5.0",
+  "ModVersion": "0.5.1",
   "ModDescription": "**Limits online play.**\n\nContains various extra patterns not in the base game.",
   "ModDll": "RNSReloaded.FuzzyMechanicPack.dll",
   "ModIcon": "",


### PR DESCRIPTION
Submitting as a PR instead of merging because:
- CLayerElementBase is still misaligned
- Other internal structs might be misaligned and need testing
- Might want to clean up some of the CRoom stuff
- and the big one: this is a change to Structs, meaning it'll require a version bump and re-publishing of every mod that uses these structs and I'd rather not have to do that for 17 mods more than I have to